### PR TITLE
Applied ivy-pot plugin to bring gradle dependencies offline

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,23 +2,63 @@
  * Exercises for Devoxx UK 2018 workshop "Getting your hands dirty with deep learning in java"
  */
 
+apply plugin: 'org.ysb33r.ivypot'
+
 buildscript {
     ext {
         dl4j_version = "0.9.1"
     }
     repositories {
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+        ivy {
+            url "file://${project.projectDir}/syncRepo"
+        }
+        if(!System.getenv('GRADLE_ONLINE')) {
+            mavenCentral()
+            maven {
+                url "https://oss.sonatype.org/content/repositories/snapshots"
+            }
+            maven {
+                url "https://plugins.gradle.org/m2/"
+            }
+        }
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:1.2.0-beta2'
+        classpath "org.ysb33r.gradle:ivypot:0.7"
+    }
+}
+
+repositories {
+    ivy {
+        url "file://${project.projectDir}/syncRepo"
+        layout 'gradle'
+    }
+    if(!System.getenv('GRADLE_ONLINE')) {
         mavenCentral()
+        maven {
+            url "https://oss.sonatype.org/content/repositories/snapshots"
+        }
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
 }
 
 subprojects {
     apply plugin: "java"
     apply plugin: "application"
+    apply plugin: 'org.ysb33r.ivypot'
     repositories {
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
-        mavenCentral()
-        jcenter()
+        ivy {
+            url "file://${project.projectDir}/syncRepo"
+            layout 'gradle'
+        }
+        if(!System.getenv('GRADLE_ONLINE')) {
+            maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+            maven { url "https://plugins.gradle.org/m2/" }
+            mavenCentral()
+            jcenter()
+        }
     }
     dependencies {
         compile "org.deeplearning4j:deeplearning4j-core:${dl4j_version}"
@@ -34,4 +74,18 @@ subprojects {
         compile "org.slf4j:slf4j-api:1.7.25"
         compile 'org.apache.httpcomponents:httpclient:4.3.5'
     }
+}
+
+syncRemoteRepositories {
+    repoRoot "${project.projectDir}/syncRepo"
+    repositories {
+        mavenCentral()
+        maven {
+            url "https://oss.sonatype.org/content/repositories/snapshots"
+        }
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+    includeBuildScriptDependencies = true
 }

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
             url "file://${project.projectDir}/syncRepo"
         }
         if(!System.getenv('GRADLE_ONLINE')) {
+            jcenter()
             mavenCentral()
             maven {
                 url "https://oss.sonatype.org/content/repositories/snapshots"
@@ -31,7 +32,6 @@ buildscript {
 repositories {
     ivy {
         url "file://${project.projectDir}/syncRepo"
-        layout 'gradle'
     }
     if(!System.getenv('GRADLE_ONLINE')) {
         mavenCentral()
@@ -51,7 +51,6 @@ subprojects {
     repositories {
         ivy {
             url "file://${project.projectDir}/syncRepo"
-            layout 'gradle'
         }
         if(!System.getenv('GRADLE_ONLINE')) {
             maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
@@ -79,6 +78,7 @@ subprojects {
 syncRemoteRepositories {
     repoRoot "${project.projectDir}/syncRepo"
     repositories {
+        jcenter()
         mavenCentral()
         maven {
             url "https://oss.sonatype.org/content/repositories/snapshots"


### PR DESCRIPTION
@davesnowdon 
I'm playing around with this config, it's giving me an error atm, still debugging.

Off the back of the inspiration from https://github.com/uli-heller/uli-gradle/tree/master/053-local-repository

Can you pls clone this branch and try to run the below command:

```
gradle syncRemoteRepositories
```

This should download all the project related repositories into your project folder, inside `syncRepo`.
