### PR TITLE
Gradle offline deps using pluging from @mdietrichstein

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ hs_err_pid*
 .gradle
 .idea
 devoxxuk2018-dl-workshop.iml
+.vagrant
+ex0-setup/build/tmp/
+hosts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM java:8u111-jdk
+
+RUN apt-get update && apt-get install -y \
+				maven \
+				gradle \
+                curl \
+                git \
+        --no-install-recommends && rm -r /var/lib/apt/lists/*
+
+RUN cd $HOME && git clone http://github.com/davesnowdon/devoxxuk2018-dl-workshop.git
+RUN cd $HOME/devoxxuk2018-dl-workshop && \
+    chmod +x gradlew && \
+    ./gradlew
+RUN ./gradlew updateOfflineRepository -PofflineRepositoryRoot=./offline-repository
+RUN ./gradlew -PofflineRepositoryRoot=./offline-repository :ex0-setup:ex0run --offline
+
+VOLUME ./offline-repository $HOME/devoxxuk2018-dl-workshop/dl-workshop-git-repo/offline-repository

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,54 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$script = <<SCRIPT
+sudo apt-get install tree -y
+sudo apt-get install software-properties-common
+sudo apt-add-repository ppa:ansible/ansible
+sudo add-apt-repository ppa:webupd8team/java
+sudo apt-get update
+sudo apt-get install -y oracle-java8-installer \
+                        oracle-java8-set-default \
+                        git \
+                        maven \
+                        gradle \
+                        ansible
+sudo mkdir /ansible
+sudo cp /etc/ansible/ansible.cfg /ansible
+sudo touch /ansible/hosts
+sudo sed -i 's?#inventory      = /etc/ansible/hosts?inventory = /ansible/hosts?g' /ansible/ansible.cfg
+echo "---------------------------------------------------------------------------------------"
+echo "*** Creating public-private keypair for ansible-playbook... for user '$USER' *** "
+yes y | ssh-keygen -t rsa -b 4096 -C "devoxx-dl-workshop@example.com" -q -P "" -f $HOME/.ssh/id_rsa
+echo "---------------------------------------------------------------------------------------"
+echo "*** Public-private keypair for ansible-playbook... for user '$USER' has been created in *** "
+ls -lash $HOME/.ssh
+echo "---------------------------------------------------------------------------------------"
+export VAGRANT_MOUNT=/vagrant
+echo "*** Creating 'hosts' file for ansible-playbook... ***"
+echo "localhost ansible_connection=local" > $VAGRANT_MOUNT/hosts
+echo "---------------------------------------------------------------------------------------"
+echo "*** '$VAGRANT_MOUNT/hosts' file for ansible-playbook contains ***"
+cat $VAGRANT_MOUNT/hosts
+echo "*** Checking the version of Java installed ***"
+java -version
+echo "*** Cloning the devoxxuk2018-dl-workshop library ***"
+cd $HOME && git clone http://github.com/davesnowdon/devoxxuk2018-dl-workshop.git
+cd $HOME/devoxxuk2018-dl-workshop
+ls
+chmod +x gradlew
+./gradlew
+./gradlew updateOfflineRepository -PofflineRepositoryRoot=./offline-repository
+./gradlew -PofflineRepositoryRoot=./offline-repository :ex0-setup:ex0run --offline
+echo "---------------------------------------------------------------------------------------"
+SCRIPT
+
+Vagrant.configure("2") do |config|
+
+  config.vm.define :dlworkshop do |dlworkshop|
+    dlworkshop.vm.box = "ubuntu/trusty64"
+    dlworkshop.vm.hostname = "dlworkshop"
+    dlworkshop.vm.network :private_network, type: "dhcp"
+    dlworkshop.vm.provision "shell", inline: $script, privileged: false
+  end
+end

--- a/build.gradle
+++ b/build.gradle
@@ -2,13 +2,49 @@
  * Exercises for Devoxx UK 2018 workshop "Getting your hands dirty with deep learning in java"
  */
 
+apply plugin: 'io.pry.gradle.offline_dependencies'
+apply plugin: 'java'
+
+dl4j_version = "0.9.1"
+
 buildscript {
     ext {
         dl4j_version = "0.9.1"
     }
     repositories {
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+        maven { url offlineRepositoryRoot }
+        maven { url 'https://plugins.gradle.org/m2/' }
         mavenCentral()
+        jcenter()
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+    }
+    dependencies {
+        classpath 'gradle.plugin.io.pry.gradle.offline_dependencies:gradle-offline-dependencies-plugin:0.3'
+        classpath "org.deeplearning4j:deeplearning4j-core:${dl4j_version}"
+        classpath "org.deeplearning4j:deeplearning4j-ui_2.11:${dl4j_version}"
+        // use the following to use CPU
+        classpath "org.nd4j:nd4j-native-platform:${dl4j_version}"
+        // or the following to use GPU (requires CUDA8 already installed)
+        //compile "org.nd4j:nd4j-cuda-8.0-platform:${dl4j_version}"
+        classpath 'jfree:jfreechart:1.0.13'
+        //classpath 'org.jfree:jcommon:1.0.13'
+        //classpath 'com.oracle:javafx:2.2.3'
+        classpath "org.slf4j:slf4j-simple:1.7.25"
+        classpath "org.slf4j:slf4j-api:1.7.25"
+        classpath 'org.apache.httpcomponents:httpclient:4.3.5'
+    }
+}
+
+repositories {
+    maven { url offlineRepositoryRoot }
+}
+
+offlineDependencies {
+    repositories {
+        maven { url 'https://plugins.gradle.org/m2/' }
+        mavenCentral()
+        jcenter()
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     }
 }
 
@@ -16,10 +52,13 @@ subprojects {
     apply plugin: "java"
     apply plugin: "application"
     repositories {
+        maven { url offlineRepositoryRoot }
+        maven { url 'https://plugins.gradle.org/m2/' }
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
         jcenter()
     }
+
     dependencies {
         compile "org.deeplearning4j:deeplearning4j-core:${dl4j_version}"
         compile "org.deeplearning4j:deeplearning4j-ui_2.11:${dl4j_version}"


### PR DESCRIPTION
Please ignore PR #1 for now!

- loads dependencies offline into a local folder inside the project
- allows running project tasks in offline mode using `--offline` flag (needs testing and tweaking on a clean environment)
- Dockerfile and Vagrantfile to help create clean isolated environments have been added (needs further testing and tweaking)

### Usage:

CLI (non-container environment):
- `gradle updateOfflineRepository -PofflineRepositoryRoot=./offline-repository` (to install he offline plugin first)
- `gradle updateOfflineRepository -PofflineRepositoryRoot=./offline-repository  :ex0-setup:ex0run` (to download dependencies into `./offline-repository` folder
- `gradle -PofflineRepositoryRoot=./offline-repository  :ex0-setup:ex0run --offline` to run the project task in offline mode

At the moment the below are containers are to test the above commands in an isolated clean environment (WIP, need your help):

### Docker usage:

Run the below in the project root directory:

To build the image containing the needed components:
```
docker build -t devoxxuk/dl-worshop:v1  .                                 
```

Run and enter the container:
```
docker run -it devoxxuk/dl-worshop:v1 /bin/bash            
```
Inside the container run these commands:

```
cd $HOME/devoxxuk2018-dl-workshop
... (to follow - I or we need to work on this still)
```

### Vagrant usage:

Run the below in the project root directory:
```
vagrant up

or

vagrant provision
```

when the box is ready, enter the box using ssh:

```
vagrant ssh
```
Inside the box navigate using commands like:

```
cd $HOME/devoxxuk2018-dl-workshop
... (to follow - I or we need to work on this still)
```